### PR TITLE
Allow folder's fullname to be empty string in TextFolder and MediaFolder 's import

### DIFF
--- a/Kooboo.CMS/Kooboo.CMS.Content/Kooboo.CMS.Content/Persistence/Default/FolderProvider.cs
+++ b/Kooboo.CMS/Kooboo.CMS.Content/Kooboo.CMS.Content/Persistence/Default/FolderProvider.cs
@@ -33,7 +33,7 @@ namespace Kooboo.CMS.Content.Persistence.Default
                 typeof(MediaFolder)
                 };
             }
-        } 
+        }
         #endregion
 
         #region IRepository<Folder> Members
@@ -105,14 +105,19 @@ namespace Kooboo.CMS.Content.Persistence.Default
             GetLocker().EnterWriteLock();
             try
             {
-                ImportHelper.Import(new FolderPath(folder).PhysicalPath, zipStream, @override);
+                string basePath = FolderPath.GetBaseDir<T>(repository);
+                if (null != folder)
+                {
+                    basePath = new FolderPath(folder).PhysicalPath;
+                }
+                ImportHelper.Import(basePath, zipStream, @override);
             }
             finally
             {
                 GetLocker().ExitWriteLock();
             }
         }
-        #endregion        
+        #endregion
     }
 
 }

--- a/Kooboo.CMS/Kooboo.CMS.Content/Kooboo.CMS.Content/Services/FolderManager.cs
+++ b/Kooboo.CMS/Kooboo.CMS.Content/Kooboo.CMS.Content/Services/FolderManager.cs
@@ -127,7 +127,11 @@ namespace Kooboo.CMS.Content.Services
         /// <param name="override">if set to <c>true</c> [@override].</param>
         public virtual void Import(Repository repository, Stream stream, string fullName, bool @override)
         {
-            var folder = FolderHelper.Parse<T>(repository, fullName);
+            T folder = null;
+            if (!String.IsNullOrEmpty(fullName))
+            {
+                folder = FolderHelper.Parse<T>(repository, fullName);
+            }
             Provider.Import(repository, folder, stream, @override);
         }
 


### PR DESCRIPTION
Allow folder's fullname to be empty string in TextFolder and MediaFolder 's import,it will import to root direcotry of TextFolder or MediaFolder if it is value is empty.
