### PR TITLE
Changes to allow .less files created, edited and deleted.

### DIFF
--- a/Kooboo.CMS/Kooboo.CMS.Sites/Services/FileManager.cs
+++ b/Kooboo.CMS/Kooboo.CMS.Sites/Services/FileManager.cs
@@ -241,7 +241,7 @@ namespace Kooboo.CMS.Sites.Services
             get
             {
                 var ex = this.FileExtension.ToLower();
-                return ex == ".txt" || ex == ".js" || ex == ".css" || ex == ".rule";
+                return ex == ".txt" || ex == ".js" || ex == ".css" || ex == ".rule" || ex == ".less";
             }
         }
 

--- a/Kooboo.CMS/Kooboo.CMS.Web/Areas/Sites/Models/DataSources/FileExtensionsDataSource.cs
+++ b/Kooboo.CMS/Kooboo.CMS.Web/Areas/Sites/Models/DataSources/FileExtensionsDataSource.cs
@@ -42,6 +42,7 @@ namespace Kooboo.CMS.Web.Areas.Sites.Models.DataSources
                 items.Add(new SelectListItem() { Text = ".js", Value = ".js" });
                 items.Add(new SelectListItem() { Text = ".css", Value = ".css" });
                 items.Add(new SelectListItem() { Text = ".txt", Value = ".txt" });
+                items.Add(new SelectListItem() { Text = ".less", Value = ".less" });
             }
             return items;
         }

--- a/Kooboo.CMS/Kooboo.CMS.Web/Areas/Sites/Views/File/EditorTemplates/FileEditor.cshtml
+++ b/Kooboo.CMS/Kooboo.CMS.Web/Areas/Sites/Views/File/EditorTemplates/FileEditor.cshtml
@@ -58,6 +58,10 @@
                 '.txt': function () {
                     this.common();
                     codeMirrorAPI.setOption('mode', 'text/html');
+                },
+                '.less': function () {
+                    this.common();
+                    codeMirrorAPI.setOption('mode', 'css');
                 }
             },
             option: {
@@ -65,6 +69,9 @@
 
                 },
                 '.css': {
+
+                },
+                '.less': {
 
                 },
                 '.txt': {
@@ -75,7 +82,7 @@
                 }
             },
             handle: function (extension) {
-                var quickExp = /.js|.css|.txt|.rule/i;
+                var quickExp = /.js|.css|.txt|.less|.rule/i;
 
                 var group = quickExp.exec(extension);
 
@@ -99,7 +106,7 @@
         };
         var fileExtension = $('#FileExtension');
         if (fileExtension.length) {
-            var quickExp = /.js|.css|.txt|.rule/;
+            var quickExp = /.js|.css|.txt|.less|.rule/;
 
             fileExtension.change(function () {
                 dic.handle($(this).val());


### PR DESCRIPTION
Fixes #152
This change is for the Custom Files folder only.

Main developers can decide if they want this to be allowed in the scripts folder.

There are currently no way to edit .less files from within Kooboo.  This is not a requirement, but allows the developer to modify .less files for compile outside the Kooboo framework without leaving Kooboo to edit the files.  Sites could then be exported to include the .less files.

Note: There may be a need for other extensions. In example, sass and other css frameworks that use preprocessors.
